### PR TITLE
fix(.slugignore): ignore yarn.lock on deploy

### DIFF
--- a/.slugignore
+++ b/.slugignore
@@ -1,0 +1,1 @@
+yarn.lock


### PR DESCRIPTION
## Description

Add .slugignore to avoid Heroku run yarn.lock on deploy

Closes #18 

<!--
Things to cite on the PR description:

- Why is the PR needed
- What the PR does
- What are possible side effects
- Additional information (related github issues, links, etc)

  Example: This PR implements feature "x" so we can solve our payments problem. This PR closes #98928312874 (github issue)
-->

## Your checklist for this pull request

:rotating_light: Please review this items for a good pull request. :four_leaf_clover:

1. I've read the project's [Contributing Guidelines](CONTRIBUTING.md)
1. My commits are well written and follow [pagarme/git-style-guide](https://github.com/pagarme/git-style-guide)
1. My changes are well covered by **tests** and **logs**
1. I've updated the project docs (if needed)
1. I fell safe about this implementation

In a good pull request, everything above is true :relaxed: